### PR TITLE
fix: cluster-name in sysdig and add cluster-name tag to logdna

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Cluster id to add to agents to | `string` | n/a | yes |
 | <a name="input_cluster_resource_group_id"></a> [cluster\_resource\_group\_id](#input\_cluster\_resource\_group\_id) | Resource group of the cluster | `string` | n/a | yes |
+| <a name="input_logdna_add_cluster_name"></a> [logdna\_add\_cluster\_name](#input\_logdna\_add\_cluster\_name) | Add cluster name to the list of tags | `bool` | `true` | no |
 | <a name="input_logdna_agent_tags"></a> [logdna\_agent\_tags](#input\_logdna\_agent\_tags) | array of tags to group the host logs pushed by the logdna agent | `list(string)` | `[]` | no |
 | <a name="input_logdna_agent_version"></a> [logdna\_agent\_version](#input\_logdna\_agent\_version) | Version of the agent to deploy. To lookup version run: `ibmcloud cr images --restrict ext/logdna-agent`. If null, the default value is used. | `string` | `"3.8.0-20230206.cbc937fa5513f636"` | no |
 | <a name="input_logdna_enabled"></a> [logdna\_enabled](#input\_logdna\_enabled) | Deploy IBM Cloud Logging agent | `bool` | `true` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -105,4 +105,5 @@ module "observability_agents" {
   sysdig_instance_name      = module.observability_instances.sysdig_name
   sysdig_access_key         = module.observability_instances.sysdig_access_key
   logdna_agent_tags         = var.logdna_agent_tags
+  logdna_add_cluster_name   = true
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -35,6 +35,16 @@
       "cloud_data_type": "resource_group",
       "computed": true
     },
+    "logdna_add_cluster_name": {
+      "name": "logdna_add_cluster_name",
+      "type": "bool",
+      "description": "Add cluster name to the list of tags",
+      "default": true,
+      "pos": {
+        "filename": "variables.tf",
+        "line": 55
+      }
+    },
     "logdna_agent_tags": {
       "name": "logdna_agent_tags",
       "type": "list(string)",
@@ -114,7 +124,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 81
+        "line": 87
       }
     },
     "sysdig_agent_version": {
@@ -124,7 +134,7 @@
       "default": "12.10.1",
       "pos": {
         "filename": "variables.tf",
-        "line": 73
+        "line": 79
       }
     },
     "sysdig_enabled": {
@@ -138,7 +148,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 55
+        "line": 61
       }
     },
     "sysdig_instance_name": {
@@ -151,7 +161,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 61
+        "line": 67
       }
     },
     "sysdig_resource_group_id": {
@@ -160,7 +170,7 @@
       "description": "Resource group that the IBM Cloud Monitoring is in. Defaults to Clusters group",
       "pos": {
         "filename": "variables.tf",
-        "line": 67
+        "line": 73
       }
     }
   },
@@ -195,7 +205,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 67
+        "line": 68
       }
     },
     "helm_release.sysdig_agent": {
@@ -210,7 +220,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 121
+        "line": 122
       }
     }
   },

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -63,9 +63,6 @@ func TestRunBasicAgents(t *testing.T) {
 func TestRunUpgrade(t *testing.T) {
 	t.Parallel()
 
-	// TODO: Remove this line after the first merge to primary branch is complete to enable upgrade test
-	t.Skip("Skipping upgrade test until initial code is in primary branch")
-
 	options := setupOptions(t, "observ-agents-upg", terraformDirOther)
 
 	output, err := options.RunTestUpgrade()

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "logdna_ingestion_key" {
   default     = null
 }
 
+variable "logdna_add_cluster_name" {
+  type        = bool
+  description = "Add cluster name to the list of tags"
+  default     = true
+}
+
 variable "sysdig_enabled" {
   type        = bool
   description = "Deploy IBM Cloud Monitoring agent"


### PR DESCRIPTION
### Description

Issue 1: Currently the cluster id was visible in the sysdig when deployed using the module.

Issue 2: Add cluster name to the list of tags to the logdna so that customer can sort the logs based on cluster name tag. The clustername tag should be added based on the variable `logdna_add_cluster_name `.

Issue: 
https://github.com/terraform-ibm-modules/terraform-ibm-observability-agents/issues/90
https://github.com/terraform-ibm-modules/terraform-ibm-observability-agents/issues/89

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
