### PR TITLE
fix: update kubectl rollout status timeout to 30mins

### DIFF
--- a/scripts/confirm-rollout-status.sh
+++ b/scripts/confirm-rollout-status.sh
@@ -5,4 +5,4 @@ set -e
 daemonset=$1
 namespace=$2
 
-kubectl rollout status ds "${daemonset}" -n "${namespace}" --timeout 15m
+kubectl rollout status ds "${daemonset}" -n "${namespace}" --timeout 30m


### PR DESCRIPTION
### Description

Looks like the rollout of sysdig pods timed out:
```
 2023/04/25 08:29:02 Terraform apply | Error running command
 2023/04/25 08:29:02 Terraform apply | '.terraform/modules/ocp_all_inclusive.observability_agents/scripts/confirm-rollout-status.sh
 2023/04/25 08:29:02 Terraform apply | sysdig-agent ibm-observe': exit status 1. Output: Waiting for daemon set
 2023/04/25 08:29:02 Terraform apply | "sysdig-agent" rollout to finish: 0 of 9 updated pods are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 1 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 2 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 3 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 4 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 5 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 6 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 7 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | Waiting for daemon set "sysdig-agent" rollout to finish: 8 of 9 updated pods
 2023/04/25 08:29:02 Terraform apply | are available...
 2023/04/25 08:29:02 Terraform apply | error: timed out waiting for the condition
 2023/04/25 08:29:02 Terraform apply | 
```

However when I checked the cluster, I see that all sysdig pods are up:
```
% oc get pods -n ibm-observe
NAME                 READY   STATUS    RESTARTS   AGE
logdna-agent-4xwk7   1/1     Running   0          5h8m
logdna-agent-9dpp7   1/1     Running   0          5h8m
logdna-agent-b5kz5   1/1     Running   0          5h8m
logdna-agent-cmxf8   1/1     Running   0          5h8m
logdna-agent-g8kp6   1/1     Running   0          5h8m
logdna-agent-gmxf4   1/1     Running   0          5h8m
logdna-agent-gpzcz   1/1     Running   0          5h8m
logdna-agent-gv7m8   1/1     Running   0          5h8m
logdna-agent-rgzmq   1/1     Running   0          5h8m
sysdig-agent-6ntrg   1/1     Running   0          5h8m
sysdig-agent-8c5pw   1/1     Running   0          5h8m
sysdig-agent-f9cpb   1/1     Running   0          5h8m
sysdig-agent-mr8z7   1/1     Running   0          5h8m
sysdig-agent-qlxsj   1/1     Running   0          5h8m
sysdig-agent-w7ljx   1/1     Running   0          5h8m
sysdig-agent-xqlcw   1/1     Running   0          5h8m
sysdig-agent-z2wvp   1/1     Running   0          5h8m
sysdig-agent-zlpb7   1/1     Running   0          5h8m
```

When I dug into each of the pods, I noticed that `sysdig-agent-8c5pw` was not ready until 08:39 UTC, yet our kubectl rollout timeout only waited until 08:29 UTC:

`2023/04/25 08:29:02 Terraform apply | error: timed out waiting for the condition`

![image](https://media.github.ibm.com/user/42199/files/08a4d06c-7a32-4ab9-92dd-4c424ab50bb8)

Turns out the timeout in the `confirm-rollout-status.sh` is only set to 15mins, so this PR will update it to 30mins

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
