### PR TITLE
chore: add support for default_ocp_version

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -60,13 +60,13 @@ resource "ibm_resource_instance" "cos_instance" {
 # Lookup the current default kube version
 data "ibm_container_cluster_versions" "cluster_versions" {}
 locals {
-  default_kube_version = "${data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions[length(data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions) - 1]}_openshift"
+  default_ocp_version = "${data.ibm_container_cluster_versions.cluster_versions.default_openshift_version}_openshift"
 }
 
 resource "ibm_container_vpc_cluster" "cluster" {
   name                 = var.prefix
   vpc_id               = ibm_is_vpc.example_vpc.id
-  kube_version         = local.default_kube_version
+  kube_version         = local.default_ocp_version
   flavor               = "bx2.4x16"
   worker_count         = "2"
   entitlement          = "cloud_pak"


### PR DESCRIPTION
### Description

Use default (instead of the latest) ocp version

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
