### PR TITLE
feat: enable new endpoint type for cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You need the following permissions to run this module.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0, <1.6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.59.0 |
 
 ### Modules
 
@@ -121,6 +121,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cluster_config_endpoint_type"></a> [cluster\_config\_endpoint\_type](#input\_cluster\_config\_endpoint\_type) | Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster. | `string` | `"default"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Cluster id to add to agents to | `string` | n/a | yes |
 | <a name="input_cluster_resource_group_id"></a> [cluster\_resource\_group\_id](#input\_cluster\_resource\_group\_id) | Resource group of the cluster | `string` | n/a | yes |
 | <a name="input_logdna_add_cluster_name"></a> [logdna\_add\_cluster\_name](#input\_logdna\_add\_cluster\_name) | If true, configure the logdna agent to attach a tag containing the cluster name to all log messages. | `bool` | `true` | no |

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.59.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ data "ibm_container_cluster_config" "cluster_config" {
   cluster_name_id   = var.cluster_id
   resource_group_id = var.cluster_resource_group_id
   config_dir        = "${path.module}/kubeconfig"
+  endpoint_type     = var.cluster_config_endpoint_type != "default" ? var.cluster_config_endpoint_type : null # null value represents default
 }
 
 ##############################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -118,4 +118,15 @@ variable "sysdig_add_cluster_name" {
   default     = true
 }
 
+variable "cluster_config_endpoint_type" {
+  description = "Specify which type of endpoint to use for for cluster config access: 'default', 'private', 'vpe', 'link'. 'default' value will use the default endpoint of the cluster."
+  type        = string
+  default     = "default"
+  nullable    = false # use default if null is passed in
+  validation {
+    error_message = "Invalid Endpoint Type! Valid values are 'default', 'private', 'vpe', or 'link'"
+    condition     = contains(["default", "private", "vpe", "link"], var.cluster_config_endpoint_type)
+  }
+}
+
 ##############################################################################

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,7 @@ terraform {
     ibm = {
       # Use "greater than or equal to" range in modules
       source  = "ibm-cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.59.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
### Description

In order to fully support OCP 4.13 with disabled public endpoint, the IBM provider team has added a new parameter `endpoint_type` to the `ibm_container_cluster_config` data block to specify an endpoint type that may not be the default.

Added a new input parameter to provide the endpoint type to this module, and use this module in the `ibm_container_cluster_config` data block.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added new input variable `cluster_config_endpoint_type` that will be passed into the new parameter `endpoint_type` for the `ibm_container_cluster_config` data block used in this module.

This change will allow you to specify a different endpoint for cluster configuration than the default, for instance if using OCP 4.13 with public endpoint disabled, and you do not want to use the default endpoint of VPE, you can now specify "private" to use the private endpoint.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
