### PR TITLE
fix(deps): update default logs agent to 1.3.1

### DIFF
--- a/modules/logs-agent/main.tf
+++ b/modules/logs-agent/main.tf
@@ -21,7 +21,7 @@ data "ibm_container_cluster_config" "cluster_config" {
 
 locals {
   logs_agent_chart_location            = "oci://icr.io/ibm/observe/logs-agent-helm"
-  logs_agent_version                   = "1.3.0" # datasource: icr.io/ibm/observe/logs-agent-helm
+  logs_agent_version                   = "1.3.1" # datasource: icr.io/ibm/observe/logs-agent-helm
   logs_agent_selected_log_source_paths = distinct(concat([for namespace in var.logs_agent_log_source_namespaces : "/var/log/containers/*_${namespace}_*.log"], var.logs_agent_selected_log_source_paths))
   logs_agent_iam_api_key               = var.logs_agent_iam_api_key != null ? var.logs_agent_iam_api_key : ""
   logs_agent_trusted_profile           = var.logs_agent_trusted_profile != null ? var.logs_agent_trusted_profile : ""


### PR DESCRIPTION
### Description

Update default logs agent to 1.3.1. Renovate should be doing this, but it did not (I may need to add a special renovate rule / config since the helm repo is authenticated)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
