### PR TITLE
refactor: #12415/Cross Object Referencing and Terraform Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You need the following permissions to run this module.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.15.0, <3.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, <2.0.0 |
 

--- a/examples/obs-agent-iks/version.tf
+++ b/examples/obs-agent-iks/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Ensure that there is always 1 example locked into the lowest provider version of the range defined in the main
   # module's version.tf (this example), and 1 example that will always use the latest provider version (obs-agent-ocp).

--- a/examples/obs-agent-ocp/version.tf
+++ b/examples/obs-agent-ocp/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Ensure that there is always 1 example locked into the lowest provider version of the range defined in the main
   # module's version.tf (obs-agent-iks), and 1 example that will always use the latest provider version (this exammple).

--- a/main.tf
+++ b/main.tf
@@ -35,20 +35,6 @@ locals {
   cloud_monitoring_agent_registry   = "icr.io/ext/sysdig/agent"
   cloud_monitoring_agent_tags       = var.cloud_monitoring_add_cluster_name ? concat(["ibm.containers-kubernetes.cluster.name:${local.cluster_name}"], var.cloud_monitoring_agent_tags) : var.cloud_monitoring_agent_tags
   cloud_monitoring_host             = var.cloud_monitoring_enabled ? var.cloud_monitoring_endpoint_type == "private" ? "ingest.private.${var.cloud_monitoring_instance_region}.monitoring.cloud.ibm.com" : "logs.${var.cloud_monitoring_instance_region}.monitoring.cloud.ibm.com" : null
-
-  # TODO: Move this into variable.tf since module requires 1.9 now
-  # VARIABLE VALIDATION
-  cloud_monitoring_key_validate_condition = var.cloud_monitoring_enabled == true && var.cloud_monitoring_instance_region == null && var.cloud_monitoring_access_key == null
-  cloud_monitoring_key_validate_msg       = "Values for 'cloud_monitoring_access_key' and 'log_analysis_instance_region' variables must be passed when 'cloud_monitoring_enabled = true'"
-  # tflint-ignore: terraform_unused_declarations
-  cloud_monitoring_key_validate_check = regex("^${local.cloud_monitoring_key_validate_msg}$", (!local.cloud_monitoring_key_validate_condition ? local.cloud_monitoring_key_validate_msg : ""))
-  # Logs Agent Validation
-  # tflint-ignore: terraform_unused_declarations
-  validate_iam_mode = var.logs_agent_enabled == true && (var.logs_agent_iam_mode == "IAMAPIKey" && (var.logs_agent_iam_api_key == null || var.logs_agent_iam_api_key == "")) ? tobool("When passing 'IAMAPIKey' value for 'logs_agent_iam_mode' you cannot set 'logs_agent_iam_api_key' as null or empty string.") : true
-  # tflint-ignore: terraform_unused_declarations
-  validate_trusted_profile_mode = var.logs_agent_enabled == true && (var.logs_agent_iam_mode == "TrustedProfile" && (var.logs_agent_trusted_profile == null || var.logs_agent_trusted_profile == "")) ? tobool(" When passing 'TrustedProfile' value for 'logs_agent_iam_mode' you cannot set 'logs_agent_trusted_profile' as null or empty string.") : true
-  # tflint-ignore: terraform_unused_declarations
-  validate_icl_ingress_endpoint = var.logs_agent_enabled == true && (var.cloud_logs_ingress_endpoint == null || var.cloud_logs_ingress_endpoint == "") ? tobool("When 'logs_agent_enabled' is enabled, you cannot set 'cloud_logs_ingress_endpoint' as null or empty string.") : true
 }
 
 /** Cloud Monitoring Configuration Start **/

--- a/modules/logs-agent/README.md
+++ b/modules/logs-agent/README.md
@@ -59,7 +59,7 @@ module "logs_agent_module" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.11.0, <3.0.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.59.0, <2.0.0 |
 

--- a/modules/logs-agent/version.tf
+++ b/modules/logs-agent/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Each required provider's version should be a flexible range to future proof the module's usage with upcoming minor and patch versions.
   required_providers {

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,14 @@ variable "cloud_monitoring_enabled" {
   type        = bool
   description = "Deploy IBM Cloud Monitoring agent"
   default     = true
+
+  validation {
+    condition = !var.cloud_monitoring_enabled || (
+      var.cloud_monitoring_access_key != null &&
+      var.cloud_monitoring_instance_region != null
+    )
+    error_message = "When cloud_monitoring_enabled is true, both cloud_monitoring_access_key and cloud_monitoring_instance_region must be provided."
+  }
 }
 
 variable "cloud_monitoring_access_key" {
@@ -196,6 +204,15 @@ variable "logs_agent_trusted_profile" {
   type        = string
   description = "The IBM Cloud trusted profile ID. Used only when `logs_agent_iam_mode` is set to `TrustedProfile`. The trusted profile must have an IBM Cloud Logs `Sender` role."
   default     = null
+
+  validation {
+    condition = (
+      var.logs_agent_enabled == false ||
+      var.logs_agent_iam_mode != "TrustedProfile" ||
+      (var.logs_agent_trusted_profile != null && var.logs_agent_trusted_profile != "")
+    )
+    error_message = "When passing 'TrustedProfile' value for 'logs_agent_iam_mode' you cannot set 'logs_agent_trusted_profile' as null or empty string."
+  }
 }
 
 variable "logs_agent_iam_api_key" {
@@ -203,6 +220,15 @@ variable "logs_agent_iam_api_key" {
   description = "The IBM Cloud API key for the Logs agent to authenticate and communicate with the IBM Cloud Logs. It is required if `logs_agent_iam_mode` is set to `IAMAPIKey`."
   sensitive   = true
   default     = null
+
+  validation {
+    condition = (
+      var.logs_agent_enabled == false ||
+      var.logs_agent_iam_mode != "IAMAPIKey" ||
+      (var.logs_agent_iam_api_key != null && var.logs_agent_iam_api_key != "")
+    )
+    error_message = "When passing 'IAMAPIKey' value for 'logs_agent_iam_mode', you cannot set 'logs_agent_iam_api_key' as null or empty string."
+  }
 }
 
 variable "logs_agent_tolerations" {
@@ -278,6 +304,14 @@ variable "cloud_logs_ingress_endpoint" {
   description = "The host for IBM Cloud Logs ingestion. Ensure you use the ingress endpoint. See https://cloud.ibm.com/docs/cloud-logs?topic=cloud-logs-endpoints_ingress."
   type        = string
   default     = null
+
+  validation {
+    condition = (
+      var.logs_agent_enabled == false ||
+      (var.cloud_logs_ingress_endpoint != null && var.cloud_logs_ingress_endpoint != "")
+    )
+    error_message = "When 'logs_agent_enabled' is enabled, you cannot set 'cloud_logs_ingress_endpoint' as null or empty string."
+  }
 }
 
 variable "cloud_logs_ingress_port" {

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   # Each required provider's version should be a flexible range to future proof the module's usage with upcoming minor and patch versions.
   required_providers {


### PR DESCRIPTION
### Description
* Upgraded terraform version to 1.9.0
* Migrated and tested 4 Validations to variables.tf for main module.
[Issue](https://github.ibm.com/GoldenEye/issues/issues/12415)

### Validation Tests
Case 1 :
``` text
cloud_monitoring_enabled         = true
cloud_monitoring_access_key      = null
cloud_monitoring_instance_region = null
```
Case 2 :
``` text
cloud_monitoring_enabled         = true
cloud_monitoring_access_key      = null
cloud_monitoring_instance_region = ""
```
Case 3 :
``` text
cloud_monitoring_enabled         = true
cloud_monitoring_access_key      = ""
cloud_monitoring_instance_region = null
``` 
All the above cases leads to the following error
<img width="1502" alt="Screenshot 2025-04-16 at 3 58 33 PM" src="https://github.com/user-attachments/assets/555da7be-b938-447e-8678-f5e4084ea4de" />
Which is resolved with
``` text
cloud_monitoring_enabled         = true
cloud_monitoring_access_key      = ""
cloud_monitoring_instance_region = ""
``` 
Case 4 :
```text
logs_agent_enabled     = true
cloud_logs_ingress_endpoint     = null
```
Case 5 :
```text
logs_agent_enabled      = true
cloud_logs_ingress_endpoint     = ""
```
Case 4 and 5 leads to the following error
<img width="1038" alt="Screenshot 2025-04-16 at 4 05 18 PM" src="https://github.com/user-attachments/assets/62a9b42c-f889-4bd8-b3e4-570b77814f2b" />
which is resolved with
```text
logs_agent_enabled        = true
cloud_logs_ingress_endpoint     = "Non Empty String"
```
Case 6 :
```text
logs_agent_enabled               = true
logs_agent_iam_mode              = "TrustedProfile"
logs_agent_trusted_profile       = null
```
Case 7 :
```text
logs_agent_enabled               = true
logs_agent_iam_mode              = "TrustedProfile"
logs_agent_trusted_profile       = ""
```
Case 6 and 7 leads to the following error
<img width="981" alt="Screenshot 2025-04-16 at 4 12 02 PM" src="https://github.com/user-attachments/assets/6fb43324-f7a8-474e-a7b9-4cac5233017b" />
which is resolved with
```text
logs_agent_enabled               = true
logs_agent_iam_mode              = "TrustedProfile"
logs_agent_trusted_profile       = "Non Empty String"
```
Case 8 :
```text
logs_agent_enabled               = true
logs_agent_iam_mode              = "IAMAPIKey"
logs_agent_iam_api_key       = null
```
Case 9 :
```text
logs_agent_enabled               = true
logs_agent_iam_mode              = "IAMAPIKey"
logs_agent_iam_api_key       = ""
```
Case 8 and 9 leads to the following error
<img width="919" alt="Screenshot 2025-04-16 at 4 16 11 PM" src="https://github.com/user-attachments/assets/4def4c32-f7cd-4869-9ce5-6ef3d1c60b0f" />
which is resolved with
```text
logs_agent_enabled               = true
logs_agent_iam_mode              = "IAMAPIKey"
logs_agent_iam_api_key       = "Non Empty String"
```
All validations passed when the enabled flags are false
```text
cloud_monitoring_enabled         = false
cloud_monitoring_access_key      = null
cloud_monitoring_instance_region = null
logs_agent_enabled               = false
cloud_logs_ingress_endpoint      = null
logs_agent_iam_mode              = ""
logs_agent_trusted_profile       = null
logs_agent_iam_api_key           = null
```
<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
