### PR TITLE
fix: lock ocp version

### DIFF
--- a/examples/obs-agent-ocp/variables.tf
+++ b/examples/obs-agent-ocp/variables.tf
@@ -37,7 +37,7 @@ variable "region" {
 variable "ocp_version" {
   type        = string
   description = "Version of the OCP cluster to provision"
-  default     = null
+  default     = "4.17"
 }
 
 variable "ocp_entitlement" {


### PR DESCRIPTION
### Description
With default OCP version change, 4.18 OCP is the default and hence we have to move to RHCOS. But monitoring agent has some issue fetching the libraries on RHCOS which is natively supported for RHEL 8. To overcome this issue, we can enable universal ebpf for the monitoring agent helm chart but in this module we are having old monitoring agent helm chart which does not support ebpf also. Hence, we are locking in the old version of OCP to unblock test failures.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
